### PR TITLE
feat: add doNotBroadcast parameter to /options/mint

### DIFF
--- a/docs/swagger/options-routes.yml
+++ b/docs/swagger/options-routes.yml
@@ -44,6 +44,16 @@ paths:
       tags:
         - 'options'
       summary: 'Burn options tokens'
+  /options/burnAndMint:
+    post:
+      tags:
+        - 'options'
+      summary: 'Burn options tokens and remints the supplied new ones in one multicall transaction'
+  /options/checkCollateral:
+    post:
+      tags:
+        - 'options'
+      summary: 'Checks your collateral'
   /options/calculateAccumulatedFeesBatch:
     post:
       tags:

--- a/src/connectors/panoptic/panoptic.ts
+++ b/src/connectors/panoptic/panoptic.ts
@@ -1225,15 +1225,6 @@ export class Panoptic {
     tickLimitHigh: number = this.HIGHEST_POSSIBLE_TICK,
   ): Promise<TransactionBuildingResult> {
     try {
-      console.log('executeMint args:')
-      console.log(wallet)
-      console.log(panopticPool)
-      console.log(positionIdList)
-      console.log(positionSize)
-      console.log(effectiveLiquidityLimit)
-      console.log(doNotBroadcast)
-      console.log(tickLimitLow)
-      console.log(tickLimitHigh)
       const panopticPoolContract = new Contract(panopticPool, panopticPoolAbi.abi, wallet);
 
       let gasEstimate: number;

--- a/src/options/options.requests.ts
+++ b/src/options/options.requests.ts
@@ -1,14 +1,17 @@
-import {
-  NetworkSelectionRequest,
-} from '../services/common-interfaces';
 import { BigNumber, Wallet } from 'ethers';
-import { ContractReceipt } from 'ethers';
+import { ContractReceipt, PopulatedTransaction } from 'ethers';
+
+export type TransactionBuildingResult = {
+  receipt: ContractReceipt | null;
+  unsignedTransaction: PopulatedTransaction;
+} | Error;
 
 export interface PanopticRequest {
   chain: string;
   network: string;
   connector?: string | undefined;
   address?: string;
+  doNotBroadcast?: boolean;
 }
 
 export interface PanopticPoolRequest extends PanopticRequest {
@@ -20,7 +23,8 @@ export interface BroadcastedTxResponse {
   timestamp?: number;
   nonce?: number;
   txHash?: string | BigNumber;
-  tx?: { [key: string]: any };
+  // note the difference between null and undefined here - null is for when you doNotBroadcast
+  tx?: { [key: string]: any } | null;
 }
 
 export interface EstimateGasResponse {
@@ -402,11 +406,11 @@ export interface LiquidateRequest extends PanopticPoolRequest {
   address: string;
 }
 
-export interface LiquidateResponse extends BroadcastedTxResponse{
+export interface LiquidateResponse extends BroadcastedTxResponse {
   tx: ContractReceipt;
 }
 
-export interface ExecuteMintRequest extends NetworkSelectionRequest {
+export interface ExecuteMintRequest extends PanopticRequest {
   address: string;
   positionIdList: BigNumber[];
   positionSize: BigNumber;
@@ -580,8 +584,9 @@ export interface BurnResponse {
   other?: any
 }
 
-export interface MintResponse extends BroadcastedTxResponse{
-  tx: ContractReceipt;
+export interface MintResponse extends BroadcastedTxResponse {
+  tx: ContractReceipt | null;
+  unsignedTransaction: PopulatedTransaction;
   latency?: number;
   base?: string;
   quote?: string;


### PR DESCRIPTION
I modified one of our endpoints - /options/mint - to accept a new parameter, doNotBroadcast.

When true, it prevents Hummingbot from sending a transaction from your connected wallet, and just returns the unsigned transaction payload, as seen in the screenshot.

I also tweaked the response type so that we always return the unsigned transaction payload, even if transacting, which can be useful for things like keeping an audit trail as you market make.

TODO:

- regression test - ensure stayinrange still transacts as expected without supplying doNotBroadcast
- decide internally if we want this param available on every Panoptic endpoint, or to go even farther and add it on every Hummingbot endpoint within our fork

I made a dummy testing script over on `panoptic_hummingbot` which prints the unsigned transaction payload of a Straddle, without broadcasting, showing it working:

<img width="1528" alt="Screen Shot 2024-11-13 at 10 05 05 AM" src="https://github.com/user-attachments/assets/3a4aa6f8-6771-453c-900f-c8c318758168">
