### PR TITLE
feat: add doNotBroadcast + unsignedTransactionPayload to all state-writing Panoptic endpoints

### DIFF
--- a/src/options/options.requests.ts
+++ b/src/options/options.requests.ts
@@ -25,6 +25,7 @@ export interface BroadcastedTxResponse {
   txHash?: string | BigNumber;
   // note the difference between null and undefined here - null is for when you doNotBroadcast
   tx?: { [key: string]: any } | null;
+  unsignedTransaction: PopulatedTransaction;
 }
 
 export interface EstimateGasResponse {
@@ -394,7 +395,7 @@ export interface ForceExerciseRequest extends PanopticPoolRequest {
 }
 
 export interface ForceExerciseResponse extends BroadcastedTxResponse{
-  tx: ContractReceipt;
+  tx: ContractReceipt | null;
 }
 
 export interface LiquidateRequest extends PanopticPoolRequest {
@@ -407,7 +408,7 @@ export interface LiquidateRequest extends PanopticPoolRequest {
 }
 
 export interface LiquidateResponse extends BroadcastedTxResponse {
-  tx: ContractReceipt;
+  tx: ContractReceipt | null;
 }
 
 export interface ExecuteMintRequest extends PanopticRequest {
@@ -444,7 +445,7 @@ export interface PokeMedianRequest extends PanopticPoolRequest {
 }
 
 export interface PokeMedianResponse extends BroadcastedTxResponse{
-  tx: ContractReceipt;
+  tx: ContractReceipt | null;
 }
 
 export interface SettleLongPremiumRequest extends PanopticPoolRequest {
@@ -456,7 +457,7 @@ export interface SettleLongPremiumRequest extends PanopticPoolRequest {
 }
 
 export interface SettleLongPremiumResponse extends BroadcastedTxResponse{
-  tx: ContractReceipt;
+  tx: ContractReceipt | null;
 }
 
 export interface DepositRequest extends PanopticRequest {
@@ -476,7 +477,7 @@ export interface GetAssetRequest extends PanopticRequest {
   address: string;
 }
 
-export interface GetAssetResponse extends BroadcastedTxResponse{
+export interface GetAssetResponse {
   assetTokenAddress?: string;
 }
 
@@ -559,8 +560,8 @@ export interface GetAccountFeesBaseResponse {
   feesBase1: BigNumber;
 }
 
-export interface BurnResponse {
-  tx: ContractReceipt;
+export interface BurnResponse extends BroadcastedTxResponse {
+  tx: ContractReceipt | null;
   network?: string;
   timestamp?: number;
   latency?: number;
@@ -586,7 +587,6 @@ export interface BurnResponse {
 
 export interface MintResponse extends BroadcastedTxResponse {
   tx: ContractReceipt | null;
-  unsignedTransaction: PopulatedTransaction;
   latency?: number;
   base?: string;
   quote?: string;


### PR DESCRIPTION
**A description of the changes proposed in the pull request**:
In this previous PR, we added:

- doNotBroadcast as an argument to all state-writing Panoptic endpoints (but only respected it on `options/mint`
- returned unsignedTransactionPayload on MintResponse so that you could, if you so chose, use the gateway just for transaction building and did not allow your wallet to be imported and signing transactions there. You could instead use the returned values to sign and broadcast in your own setup

Now, in this PR, we:

- respect doNotBroadcast on all endpoints
- elevate unsignedTransactionPayload as a mandatory field on all `BroadcastedTxResponse`s (which is now a misnomer and should probably be renamed in the future)


**Tests performed by the developer**:

Example returned unsignedTransactionPayload for a pokeMedian call that I have confirmed was not broadcasted (as intended):

<img width="904" alt="Screen Shot 2024-11-19 at 9 09 58 AM" src="https://github.com/user-attachments/assets/d50fb95d-67e1-4e9d-b1e4-c1d49437a102">

And regression-testing wise, i re-ran the stayInrange script on the T0/T1 pool (whose price has moved since we last ran it) and i successfully got the expected burn and mint: https://sepolia.etherscan.io/tx/0xa5e8032268a920d612c1b0c5a40f2c1cac9cb81dff98e0425dabe60043be0e28

